### PR TITLE
Change appId key to match the iOS side of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For help on editing plugin code, view the [documentation](https://flutter.io/dev
 | name       | type      | default | description                                                                                                                    |
 | ---------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `afDevKey` | `string`  |         | [Appsflyer Dev key](https://support.appsflyer.com/hc/en-us/articles/207032126-AppsFlyer-SDK-Integration-Android)               |
-| `appId`    | `string`  |         | [Apple Application ID](https://support.appsflyer.com/hc/en-us/articles/207032066-AppsFlyer-SDK-Integration-iOS) (for iOS only) |
+| `afAppId`  | `string`  |         | [Apple Application ID](https://support.appsflyer.com/hc/en-us/articles/207032066-AppsFlyer-SDK-Integration-iOS) (for iOS only) |
 | `isDebug`  | `boolean` | `false` | debug mode (optional)                                                                                                          |
 
 _Example:_
@@ -50,7 +50,7 @@ import 'package:appsflyer_sdk/appsflyer_sdk.dart';
 //..
 
 Map options = { "afDevKey": afDevKey,
-                "appId": appId,
+                "afAppId": appId,
                 "isDebug": true};
 
 AppsflyerSdk appsflyerSdk = AppsflyerSdk(appsFlyerOptions);

--- a/lib/appsflyer_constants.dart
+++ b/lib/appsflyer_constants.dart
@@ -1,6 +1,6 @@
 class AppsflyerConstants {
   static const String AF_DEV_KEY = "afDevKey";
-  static const String AF_APP_Id = "appId";
+  static const String AF_APP_Id = "afAppId";
   static const String AF_IS_DEBUG = "isDebug";
   static const String AF_GCD = "GCD";
 


### PR DESCRIPTION
Currently the plugin doesn't work for Flutter iOS apps at all.

There is a mismatch between the app id passed from Dart side and the one that the iOS side of the plugin tries to look up. On the Dart side, the key for app id is `appId`, while on the iOS side it's `afAppId`.

This PR changes the key on Dart side to `afAppId` to match what the iOS side is expecting. I also updated the README to have the correct key there as well.

To see what's the problem with the current version, see the specific lines here:
* **"appId"** on Dart side of the plugin
https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk/blob/c5e3050057872efe166b3194fe41c72edb7e7568/lib/appsflyer_constants.dart#L3
* **"afAppId"** on iOS side of the plugin
https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk/blob/c5e3050057872efe166b3194fe41c72edb7e7568/ios/Classes/AppsflyerSdkPlugin.h#L11