### PR TITLE
Update AppsflyerSdkPlugin.java

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
@@ -3,6 +3,7 @@ package com.appsflyer.appsflyersdk;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
+import android.content.Intent;
 import android.util.Log;
 
 import com.appsflyer.AFLogger;


### PR DESCRIPTION
Add  'import android.content.Intent;' to solve the following issue:
flutter/.pub-cache/hosted/pub.dartlang.org/appsflyer_sdk-1.1.0/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java:50: error: cannot find symbol
    private Intent mIntent;